### PR TITLE
Implement an option to disable Elytra while in combat

### DIFF
--- a/common/src/main/java/me/toastymop/combatlog/CombatCheck.java
+++ b/common/src/main/java/me/toastymop/combatlog/CombatCheck.java
@@ -3,21 +3,27 @@ package me.toastymop.combatlog;
 import me.toastymop.combatlog.util.IEntityDataSaver;
 import me.toastymop.combatlog.util.TagData;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
-
-import java.util.Objects;
 
 public class CombatCheck {
     public static void CheckCombat(Entity entity) {
-        LivingEntity target = (LivingEntity) entity;
-        if (target instanceof PlayerEntity) {
-            if ((target.getAttacker() instanceof PlayerEntity) && ((ServerPlayerEntity) target).interactionManager.getGameMode().isSurvivalLike() && ((ServerPlayerEntity) Objects.requireNonNull(target.getAttacker())).interactionManager.getGameMode().isSurvivalLike()) {
-                TagData.setTagTime((IEntityDataSaver) target);
-                TagData.setTagTime((IEntityDataSaver) target.getAttacker());
+        // Contributor note: I have refactored this method a bit
+        // to make it a bit easier to read
+        // and remove some unnecessary code like multiple casts, instead of one
+        if (entity instanceof ServerPlayerEntity player) {
+            if ((player.getAttacker() instanceof ServerPlayerEntity attacker) && player.interactionManager.getGameMode().isSurvivalLike() && attacker.interactionManager.getGameMode().isSurvivalLike()) {
+                TagData.setTagTime((IEntityDataSaver) player);
+                if (CombatConfig.disableElytra) {
+                    // Stop the player who took damage from flying
+                    // The attacker will be able to fly until taking damage from another player or until it lands
+                    player.stopFallFlying();
+                    if (CombatConfig.attackerNoFly) {
+                        attacker.stopFallFlying();
+                    }
+                }
+                TagData.setTagTime((IEntityDataSaver) attacker);
             } else if (CombatConfig.allDamage) {
-                TagData.setTagTime((IEntityDataSaver) target);
+                TagData.setTagTime((IEntityDataSaver) player);
             }
         }
 

--- a/common/src/main/java/me/toastymop/combatlog/CombatCheck.java
+++ b/common/src/main/java/me/toastymop/combatlog/CombatCheck.java
@@ -10,8 +10,10 @@ public class CombatCheck {
         // Contributor note: I have refactored this method a bit
         // to make it a bit easier to read
         // and remove some unnecessary code like multiple casts, instead of one
-        if (entity instanceof ServerPlayerEntity player) {
-            if ((player.getAttacker() instanceof ServerPlayerEntity attacker) && player.interactionManager.getGameMode().isSurvivalLike() && attacker.interactionManager.getGameMode().isSurvivalLike()) {
+        if (entity instanceof ServerPlayerEntity && ((ServerPlayerEntity)entity).getAttacker() instanceof ServerPlayerEntity) {
+            ServerPlayerEntity player = (ServerPlayerEntity) entity;
+            ServerPlayerEntity attacker = (ServerPlayerEntity) player.getAttacker();
+            if (player.interactionManager.getGameMode().isSurvivalLike() && attacker.interactionManager.getGameMode().isSurvivalLike()) {
                 TagData.setTagTime((IEntityDataSaver) player);
                 if (CombatConfig.disableElytra) {
                     // Stop the player who took damage from flying

--- a/common/src/main/java/me/toastymop/combatlog/CombatConfig.java
+++ b/common/src/main/java/me/toastymop/combatlog/CombatConfig.java
@@ -8,12 +8,16 @@ public class CombatConfig {
     static File file = new File("./config/combatlog-common.toml");
     public static int combatTime;
     public static Boolean allDamage;
+    public static Boolean disableElytra;
+    public static Boolean attackerNoFly;
     public static String deathMessage;
     public static void getConfig() {
         if (!file.exists()) {
             try {
                 combatTime = 30;
                 allDamage = false;
+                disableElytra = false;
+                attackerNoFly = false;
                 deathMessage = "\" has died of cowardice\"";
 
                 file.getParentFile().mkdirs();
@@ -24,6 +28,12 @@ public class CombatConfig {
                 fos.println("\tcombatTime = "+ combatTime);
                 fos.println("\t#Weather a player should be put in combat from just other players or all damage(true is all damage false is just players)");
                 fos.println("\tallDamage = "+ allDamage.toString());
+                fos.println("\t#Weather when in comba elytra usage should be disabled.");
+                fos.println("\tdisableElytra = "+ disableElytra.toString());
+                fos.println("\t#Should the attacker be instantly stopped from flying?");
+                fos.println("\t#If true when attacking someone when flying on elytra you will fall mid air.");
+                fos.println("\t#If false you will be able to fly until you land or until you will get damaged.");
+                fos.println("\tattackerNoFly = "+ attackerNoFly.toString());
                 fos.println("\t#The message that shows up when I player disconnects while in combat");
                 fos.println("\t#If you don't add a space to the beginning it will look like \"(player)deathmessage\" instead of \"(player) deathmessage\" ingame");
                 fos.println("\tdeathMessage = "+ deathMessage);
@@ -38,6 +48,8 @@ public class CombatConfig {
             if((config.get("config.combatTime") instanceof Integer) && (config.get("config.allDamage") instanceof Boolean)  && (config.get("config.deathMessage") instanceof String)){
                 combatTime = config.getInt("config.combatTime");
                 allDamage = config.get("config.allDamage");
+                disableElytra = config.get("config.disableElytra");
+                attackerNoFly = config.get("config.attackerNoFly");
                 deathMessage = config.get("config.deathMessage").toString();
             } else {
                 File rename = new File("./config/combatlog-common.toml.bak");

--- a/common/src/main/java/me/toastymop/combatlog/CombatConfig.java
+++ b/common/src/main/java/me/toastymop/combatlog/CombatConfig.java
@@ -45,7 +45,12 @@ public class CombatConfig {
         }else {
             FileConfig config = FileConfig.of(file);
             config.load();
-            if((config.get("config.combatTime") instanceof Integer) && (config.get("config.allDamage") instanceof Boolean)  && (config.get("config.deathMessage") instanceof String)){
+            if((config.get("config.combatTime") instanceof Integer) &&
+                    (config.get("config.allDamage") instanceof Boolean)  &&
+                    (config.get("config.disableElytra") instanceof Boolean)  &&
+                    (config.get("config.attackerNoFly") instanceof Boolean) &&
+                    (config.get("config.deathMessage") instanceof String)
+            ){
                 combatTime = config.getInt("config.combatTime");
                 allDamage = config.get("config.allDamage");
                 disableElytra = config.get("config.disableElytra");

--- a/common/src/main/java/me/toastymop/combatlog/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/me/toastymop/combatlog/mixin/PlayerEntityMixin.java
@@ -1,0 +1,21 @@
+package me.toastymop.combatlog.mixin;
+
+import me.toastymop.combatlog.CombatConfig;
+import me.toastymop.combatlog.util.IEntityDataSaver;
+import me.toastymop.combatlog.util.TagData;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerEntity.class)
+public class PlayerEntityMixin {
+
+    @Inject(method = "checkFallFlying", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;startFallFlying()V"), cancellable = true)
+    private void preventFlying(CallbackInfoReturnable<Boolean> cir) {
+        if (CombatConfig.disableElytra && TagData.getCombat((IEntityDataSaver) this)) {
+            cir.setReturnValue(false);
+        }
+    }
+}

--- a/common/src/main/resources/combatlog-common.mixins.json
+++ b/common/src/main/resources/combatlog-common.mixins.json
@@ -8,7 +8,8 @@
     "ModDisconnectMixin",
     "ModEntityDamageMixin",
     "ModEntityDataSaverMixin",
-    "ModTickMixin"
+    "ModTickMixin",
+    "PlayerEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This adds a functionality that prevent's you from using elytra in combat.
It adds two new config values.
First one, `disableElytra` allows you to enable / disable the new feature.
Disabled by default.
Second one, `attackerNoFly` is important when fighting with bows for example.
You are flying on elytra, and you shoot another player. When arrow hits him there are two cases:
1. `attackerNoFly` = `false`: You can still fly on you elytra, until you land (stop flying) or until the other player damages you.
2. `attackerNoFly` = `true`: You elytra gets diasbled mid fly, and you fall.
I also needed to refactor the code in CombatCheck a bit, to make it usable, and I also removed few unnecesary casts.
